### PR TITLE
Remove hardcoded folder

### DIFF
--- a/lib/jasperserver-rails/jasperserver-dsl.rb
+++ b/lib/jasperserver-rails/jasperserver-dsl.rb
@@ -27,7 +27,7 @@ module JasperserverRails
       login
       # Run report
       response2 = RestClient.get(
-        URI.join(Rails.configuration.jasperserver[Rails.env.to_sym][:url] + '/', "rest_v2/reports/reports/#{self.get_report}.#{self.get_format}?#{URI.encode_www_form(self.get_params)}").to_s,
+        URI.join(Rails.configuration.jasperserver[Rails.env.to_sym][:url] + '/', "rest_v2/reports/#{self.get_report}.#{self.get_format}?#{URI.encode_www_form(self.get_params)}").to_s,
         { cookies: @cookie }
       )
 


### PR DESCRIPTION
At the company I work for we have our reports organized in a hierarchical structure, for example.

- /accounting/bank1/income
- /accounting/bank2/income
- /courses/invoice
- /courses/grade_list

The code in this gem assumes every report is inside the ```reports``` folder, in our case this is not true. In order to use this gem we would have to move all our reports to the ```reports``` folder, for example.

- /reports/accounting/bank1/income
- /reports/accounting/bank2/income
- /reports/courses/invoice
- /reports/courses/grade_list

This is possible but impractical, we also would have to change every report call in all our codebase.

With this patch I propose to remove the hardcoded ```reports``` folder. Also, I assume someone else could benefit from this, which I think is a more general use case.